### PR TITLE
リクエスト時にSlackへ通知機能追加

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -1,4 +1,6 @@
 class RequestsController < ApplicationController
+  WEBHOOK_URL = 'https://hooks.slack.com/services/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'
+
     def new
     end
 
@@ -16,11 +18,11 @@ class RequestsController < ApplicationController
     end
 
     def create
-
         @bookRequest = Request.new 
         #モデルに書いたsave_with_authorメソッドを実行する
 
         if @bookRequest.save_with_request(params[:title], params[:systemid], params[:book][:authors])
+          notifier.ping("本のリクエストがありました。ISNB:#{params[:systemid]}")
           redirect_to books_path, success: t('.success')
         else
           flash.now[:danger] = t('.fail')
@@ -34,6 +36,7 @@ class RequestsController < ApplicationController
         params.require(:book).permit(:title, :systemid, authors: [])
       end
     
-    
-
+  def notifier
+    Slack::Notifier.new(WEBHOOK_URL, username: 'Codebase Book')
+  end
 end


### PR DESCRIPTION
専用のワークスペースへ通知が飛ぶよう設定
https://join.slack.com/t/codebase-edamame/shared_invite/zt-27mpjqm7a-6Ld_vAvAFwncYQ6T64KdwA
※上記ワークスペースへの招待リンクは30日後に有効期限が切れます（2023年12月25日）

<img width="1470" alt="スクリーンショット 2023-11-25 16 47 16" src="https://github.com/CODEBASE-Okinawa/codebase_books_edamame_v2/assets/137249578/a28380a6-92e3-4a79-90d9-cff8b53f21dd">
